### PR TITLE
fix: cast integer literals to bool for pymoose nanobind compatibility 

### DIFF
--- a/jardesigner/jardesigner.py
+++ b/jardesigner/jardesigner.py
@@ -833,7 +833,7 @@ print( "Wall Clock Time = {:8.2f}, simtime = {:8.3f}".format( time.time() - _sta
         if meshType == 'dend':
             mesh = moose.NeuroMesh( '/model/chem/' + chemSrc )
             mesh.geometryPolicy = 'cylinder'
-            mesh.separateSpines = 0
+            mesh.separateSpines = bool(0)
         elif meshType == 'spine':
             mesh = self.buildSpineMesh( argList, newChemId, comptDict )
         elif meshType == 'psd':
@@ -861,7 +861,7 @@ print( "Wall Clock Time = {:8.2f}, simtime = {:8.3f}".format( time.time() - _sta
             moose.le( '/model/elec' )
             raise BuildError( "Error: buildSpineMesh: Missing parent NeuroMesh '{}' for spine '{}'".format( dendMeshName, chemSrc ) )
         #print( "COMPT DICT ============", comptDict )
-        moose.element(dendMesh).separateSpines = 1
+        moose.element(dendMesh).separateSpines = bool(1)
         mesh = moose.SpineMesh( '/model/chem/' + chemSrc )
         moose.connect( dendMesh, 'spineListOut', mesh, 'spineList' )
         return mesh
@@ -913,7 +913,7 @@ print( "Wall Clock Time = {:8.2f}, simtime = {:8.3f}".format( time.time() - _sta
         mesh.isMembraneBound = True
         mesh.rScale = radiusRatio
         if meshType == 'endo_axial':
-            mesh.doAxialDiffusion = 1
+            mesh.doAxialDiffusion = bool(1)
             mesh.rPower = 0.5
             mesh.aPower = 0.5
             mesh.aScale = radiusRatio * radiusRatio
@@ -1763,7 +1763,7 @@ print( "Wall Clock Time = {:8.2f}, simtime = {:8.3f}".format( time.time() - _sta
                 func = moose.Function( funcname )
                 func.expr = i['expr']
                 #func.expr = expr
-                func.doEvalAtReinit = 1
+                func.doEvalAtReinit = bool(1)
                 for q in stimObj:
                     moose.connect( func, 'valueOut', q, stimField )
                     #print( "connecting stim: ", func.path, q.path + "[", q.dataIndex, "]." + stimField )

--- a/jardesigner/jardesignerProtos.py
+++ b/jardesigner/jardesignerProtos.py
@@ -394,7 +394,7 @@ def make_K_AHP( name ):
     K_AHP.Xpower = 0
     K_AHP.Ypower = 0
     K_AHP.Zpower = 1
-    K_AHP.useConcentration = 1
+    K_AHP.useConcentration = bool(1)
 
     zgate = moose.element( K_AHP.path + '/gateZ' )
     xmax = 0.02 # 20 micromolar.
@@ -443,7 +443,7 @@ def make_K_C( name ):
     K_C.Xpower = 1
     K_C.Zpower = 1
     K_C.instant = 4                # Flag: 0x100 means Z gate is instant.
-    K_C.useConcentration = 1
+    K_C.useConcentration = bool(1)
 
     # Now make a X-table for the voltage-dependent activation parameter.
     xgate = moose.element( K_C.path + '/gateX' )


### PR DESCRIPTION
**Problem:**
pymoose 4.2.0 replaced pybind11 with nanobind, which performs strict type checking on bool properties. Assigning plain integers (0/1) to these properties now raises a `std::bad_cast` exception at runtime, breaking any model that touches the affected fields.

**Fix:**
Wrap all affected assignments in `bool()` to satisfy nanobind's type checker without changing runtime behaviour:

| File | Property |
|---|---|
| `jardesigner.py` | `separateSpines`, `doAxialDiffusion`, `doEvalAtReinit`, |
| `jardesignerProtos.py` | `useConcentration` |

Closes #11