### PR TITLE
Switch async backend from eventlet to gevent with explicit async_mode

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,5 +8,5 @@ pymoose>=4.1.4
 numpy>=2.4.3
 Requests>=2.32.5
 Werkzeug>=3.1.6
-eventlet>=0.40.4
+gevent>=26.5.0
 urllib3>=2.6.3

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,5 +1,6 @@
-import eventlet
-eventlet.monkey_patch()
+from gevent import monkey
+monkey.patch_all()
+
 import os
 import sys
 import subprocess
@@ -31,7 +32,7 @@ app = Flask(__name__)
 CORS(app)
 
 # Quiet logging
-socketio = SocketIO(app, cors_allowed_origins="*", logger=False, engineio_logger=False)
+socketio = SocketIO(app, cors_allowed_origins="*", logger=False, engineio_logger=False, async_mode='gevent')
 
 from neuromorpho.neuromorpho_routes import neuromorpho_routes, stage_neuron as _nm_stage
 from neuromorpho.neuromorpho import search_neurons, fetch_neuron_by_id as _nm_fetch_by_id, neuron_to_item as _nm_to_item


### PR DESCRIPTION
Replaces eventlet monkey-patching and eventlet dependency with gevent, and adds async_mode='gevent' to SocketIO init to prevent auto-detection from picking the wrong mode. 

It solves windows machine packaging issue. 