### PR TITLE
fix: tutorial switching loads correct JSON

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -670,8 +670,21 @@ def load_example(client_id, name):
     if not json_path:
         return jsonify({'error': 'No jardesigner JSON found in example'}), 400
 
-    with open(json_path, 'r') as f:
-        json_content = f.read()
+    # Prefer <name>.json from the archive (same logic as upload_project)
+    json_content = None
+    preferred_path = os.path.join(session_dir, safe_name + '.json')
+    if os.path.isfile(preferred_path):
+        try:
+            with open(preferred_path, 'r') as f:
+                text = f.read()
+            if json.loads(text).get('filetype') == 'jardesigner':
+                json_content = text
+        except Exception:
+            pass
+
+    if json_content is None:
+        with open(json_path, 'r') as f:
+            json_content = f.read()
 
     return jsonify({'status': 'success', 'json': json_content})
 

--- a/frontend/src/components/DisplayWindow.jsx
+++ b/frontend/src/components/DisplayWindow.jsx
@@ -42,6 +42,7 @@ const DisplayWindow = (props) => {
   const [tabIndex, setTabIndex] = useState(0);
   const prevThreeDConfigSetup = useRef();
   const prevIsSimulating = useRef(false);
+  const prevDocFile = useRef(docFile);
 
   useEffect(() => {
     const hasNewSetupConfig = threeDConfigs?.setup && !prevThreeDConfigSetup.current;
@@ -50,6 +51,14 @@ const DisplayWindow = (props) => {
     }
     prevThreeDConfigSetup.current = threeDConfigs?.setup;
   }, [threeDConfigs?.setup, tabIndex]);
+
+  // Switch to Documentation tab when a docFile first appears (tutorial loaded or doc uploaded).
+  useEffect(() => {
+    if (docFile && docFile !== prevDocFile.current) {
+      setTabIndex(2);
+    }
+    prevDocFile.current = docFile;
+  }, [docFile]);
 
   // When a run starts, switch to Graph if plots are defined, else Run 3D.
   useEffect(() => {


### PR DESCRIPTION
- Load tutorial correctly in Model Notes.
- Auto-switches DisplayWindow to the Documentation tab when a docFile appears after a tutorial or project load.