### PR TITLE
Fix Guide tab TOC links

### DIFF
--- a/frontend/src/components/MarkdownText.jsx
+++ b/frontend/src/components/MarkdownText.jsx
@@ -53,21 +53,10 @@ function MarkdownRenderer({ markdown, scrollRef }) {
 }
 
 function GuideTab() {
-    const [htmlContent, setHtmlContent] = useState('');
-    const [loading, setLoading] = useState(true);
-
-    useEffect(() => {
-        fetch('Guide.html')
-            .then(r => { if (!r.ok) throw new Error(); return r.text(); })
-            .then(text => { setHtmlContent(text); setLoading(false); })
-            .catch(() => { setHtmlContent('<p>Could not load Guide.html</p>'); setLoading(false); });
-    }, []);
-
-    if (loading) return <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}><CircularProgress /></Box>;
     return (
         <Box sx={{ height: '100%' }}>
-            <iframe srcDoc={htmlContent} style={{ width: '100%', height: '100%', border: 'none' }}
-                    title="Jardesigner Guide" sandbox="allow-same-origin" />
+            <iframe src="Guide.html" style={{ width: '100%', height: '100%', border: 'none' }}
+                    title="Jardesigner Guide" />
         </Box>
     );
 }


### PR DESCRIPTION
Clicking a link in the Guide's Table of Contents made the page go blank. Changed the Guide tab to load Guide.html directly instead of injecting it, so the links now scroll to the right section.