### PR TITLE
Remove ICG gate fillFromExpr workaround from buildChanProto

### DIFF
--- a/jardesigner/jardesigner.py
+++ b/jardesigner/jardesigner.py
@@ -729,9 +729,6 @@ print( "Wall Clock Time = {:8.2f}, simtime = {:8.3f}".format( time.time() - _sta
                                 suffix=suffix,
                                 temperature=self.temperature,
                             )
-                    for slot in ('X', 'Y', 'Z'):
-                        if getattr( proto, slot + 'power', 0 ) > 0:
-                            moose.element( proto.path + '/gate' + slot ).fillFromExpr()
                     if proto.name != cp['name']:
                         proto.name = cp['name']
 


### PR DESCRIPTION
`buildChanProto()` previously looped over the X/Y/Z gates and called `moose.element(...).fillFromExpr()` after `channels.make_prototype()` to work around unfilled HHGate lookup tables.

This is no longer needed because the fix in **MooseNeuro/moose-core#86** makes `make_prototype()` call `HHGate.fillFromExpr()` for each gate after setting `infExpr`/`tauExpr`. 

The workaround in `jardesigner.py` can be removed once pymoose includes that change.
